### PR TITLE
 #1 streamfiles の パスの設定が正しく機能してない問題を修正

### DIFF
--- a/nodejs/viewer.js
+++ b/nodejs/viewer.js
@@ -115,7 +115,13 @@ function viewTvError(response) {
 
 function responseSpecifiedFile(response, parsedUrl, fileTypeHash) {
     var uri = parsedUrl.pathname;
-    var filename = path.join(util.getRootPath(), uri);
+    var filename;
+
+    if (uri.match(/streamfiles/)) {
+        filename = path.join(util.getConfig()["streamFilePath"], path.basename(uri));
+    } else {
+        filename = path.join(util.getRootPath(), uri);
+    }
 
     fs.exists(filename, function (exists) {
         if (!exists) {


### PR DESCRIPTION
streamfiles 配下のファイルを読みに行くとき、 config の設定を読み取って正しいファルが読み出されるように修正した
